### PR TITLE
FEAT: More IDnow SDK Options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ yarn-error.log
 
 # IDnowSDK
 ios/Frameworks/
+
+example/

--- a/android/src/main/java/com/jtec/idnow/ExpoIDnowModule.kt
+++ b/android/src/main/java/com/jtec/idnow/ExpoIDnowModule.kt
@@ -27,6 +27,11 @@ class ExpoIDnowModule : Module() {
                     activity
                 )
                 IDnowSDK.setEnvironment(options.environment.toIDnowEnvironment());
+                IDnowSDK.setShowErrorSuccessScreen(options.showErrorSuccessScreen, activity)
+                IDnowSDK.setShowVideoOverviewCheck(options.showVideoOverviewCheck, activity)
+                if(options.calledFromIDnowApp) {
+                    IDnowSDK.calledFromIDnowApp(activity)
+                }
 
                 IDnowSDK.getInstance().start(IDnowSDK.getTransactionToken()) { result, _ ->
                     promise.resolve(ExpoIDnowResponse(result).toJsonString())

--- a/android/src/main/java/com/jtec/idnow/ExpoIDnowOptions.kt
+++ b/android/src/main/java/com/jtec/idnow/ExpoIDnowOptions.kt
@@ -77,4 +77,7 @@ data class ExpoIDnowOptions(
     @Field val language: String = "de",
     @Field val connectionType: ExpoIDnowConnectionType = ExpoIDnowConnectionType.WEBSOCKET,
     @Field val environment: ExpoIDnowEnvironment = ExpoIDnowEnvironment.NOT_DEFINED,
+    @Field val showErrorSuccessScreen: Boolean = true,
+    @Field val showVideoOverviewCheck: Boolean = true,
+    @Field val calledFromIDnowApp: Boolean = true,
 ) : Record

--- a/ios/ExpoIDnowModule.swift
+++ b/ios/ExpoIDnowModule.swift
@@ -15,6 +15,8 @@ public class ExpoIDnowModule: Module {
 				settings.userInterfaceLanguage = options.language
 				settings.connectionType = options.connectionType.toIDnowConnectionType()
 				settings.environment = options.environment.toIDnowEnvironment()
+				settings.showErrorSuccessScreen = options.showErrorSuccessScreen
+				settings.showVideoOverviewCheck = options.showVideoOverviewCheck
 				
 				let controller = IDnowController(settings: settings)
 				controller.initialize(completionBlock: { _, error, cancelled in

--- a/ios/ExpoIDnowOptions.swift
+++ b/ios/ExpoIDnowOptions.swift
@@ -97,4 +97,7 @@ struct ExpoIDnowOptions: Record {
 	@Field var language: String = "de"
 	@Field var connectionType: ExpoIDnowConnectionType = .websocket
 	@Field var environment: ExpoIDnowEnvironment = .notDefined
+	@Field var showErrorSuccessScreen: Bool = true
+	@Field var showVideoOverviewCheck: Bool = true
+	@Field var calledFromIDnowApp: Bool = true
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jt-technologies/expo-idnow",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "IDnow Video Ident Expo Module",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,9 @@ export type IDnowOptions = {
   language?: string
   connectionType?: IDnowConnectionType
   environment?: IDnowEnvironment
+  showErrorSuccessScreen?: boolean
+  showVideoOverviewCheck?: boolean
+  calledFromIDnowApp?: boolean
 }
 
 export type IDnowResultType =


### PR DESCRIPTION
## New IDnow SDK Options:

- `showErrorSuccessScreen`: [iOS](https://github.com/idnow/de.idnow.ios?tab=readme-ov-file#showerrorsuccessscreen) | [Android](https://github.com/idnow/de.idnow.android?tab=readme-ov-file#usage)
- `showVideoOverviewCheck`: [iOS](https://github.com/idnow/de.idnow.ios?tab=readme-ov-file#showvideooverviewcheck) | [Android](https://github.com/idnow/de.idnow.android?tab=readme-ov-file#usage)
- `calledFromIDnowApp`: Android only